### PR TITLE
feat: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,11 @@ updates:
       time: '10:00'
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
+    groups:
+      prod-dependency:
+        dependency-type: production
+      dev-dependency:
+        dependency-type: development
     commit-message:
       prefix: "Common"
       include: "scope"


### PR DESCRIPTION
dependabotをgroupごとにPR出すように変更

https://dev.classmethod.jp/articles/dependabot-grouped-version-updates-now-generally-available/