### PR TITLE
chore: fix ci error TypeScript 5.8 → 5.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "secretlint": "^9.2.0",
         "storybook": "^8.6.3",
         "tailwindcss": "^4.0.9",
-        "typescript": "^5.8.2",
+        "typescript": "^5.7.3",
         "typescript-eslint": "^8.25.0",
         "vite": "^6",
         "vite-tsconfig-paths": "^5.1.4",
@@ -11067,21 +11067,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/eslint-plugin-prefer-arrow-functions/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
@@ -19401,9 +19386,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "secretlint": "^9.2.0",
     "storybook": "^8.6.3",
     "tailwindcss": "^4.0.9",
-    "typescript": "^5.8.2",
+    "typescript": "^5.7.3",
     "typescript-eslint": "^8.25.0",
     "vite": "^6",
     "vite-tsconfig-paths": "^5.1.4",


### PR DESCRIPTION
```
❯ npm ci
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: @typescript-eslint/utils@8.25.0
npm error Found: typescript@5.8.2
npm error node_modules/typescript
npm error   dev typescript@"^5.8.2" from the root project
npm error   peerOptional typescript@">= 4.2.x" from @storybook/react@8.6.3
npm error   node_modules/@storybook/react
npm error     dev @storybook/react@"^8.6.3" from the root project
npm error     @storybook/react@"8.6.3" from @storybook/nextjs@8.6.3
npm error     node_modules/@storybook/nextjs
npm error       dev @storybook/nextjs@"^8.6.3" from the root project
npm error     1 more (@storybook/preset-react-webpack)
npm error   31 more (@storybook/react-docgen-typescript-plugin, ...)
npm error
npm error Could not resolve dependency:
npm error peer typescript@">=4.8.4 <5.8.0" from @typescript-eslint/utils@8.25.0
npm error node_modules/@typescript-eslint/utils
npm error   peer @typescript-eslint/utils@"^8.24.0" from @vitest/eslint-plugin@1.1.36
npm error   node_modules/@vitest/eslint-plugin
npm error     dev @vitest/eslint-plugin@"^1.1.36" from the root project
npm error   @typescript-eslint/utils@"8.25.0" from @typescript-eslint/eslint-plugin@8.25.0
npm error   node_modules/eslint-config-next/node_modules/@typescript-eslint/eslint-plugin
npm error     @typescript-eslint/eslint-plugin@"^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0" from eslint-config-next@15.2.0
npm error     node_modules/eslint-config-next
npm error       dev eslint-config-next@"15.2.0" from the root project
npm error   5 more (@typescript-eslint/type-utils, ...)
npm error
npm error Conflicting peer dependency: typescript@5.7.3
npm error node_modules/typescript
npm error   peer typescript@">=4.8.4 <5.8.0" from @typescript-eslint/utils@8.25.0
npm error   node_modules/@typescript-eslint/utils
npm error     peer @typescript-eslint/utils@"^8.24.0" from @vitest/eslint-plugin@1.1.36
npm error     node_modules/@vitest/eslint-plugin
npm error       dev @vitest/eslint-plugin@"^1.1.36" from the root project
npm error     @typescript-eslint/utils@"8.25.0" from @typescript-eslint/eslint-plugin@8.25.0
npm error     node_modules/eslint-config-next/node_modules/@typescript-eslint/eslint-plugin
npm error       @typescript-eslint/eslint-plugin@"^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0" from eslint-config-next@15.2.0
npm error       node_modules/eslint-config-next
npm error         dev eslint-config-next@"15.2.0" from the root project
npm error     5 more (@typescript-eslint/type-utils, ...)
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/jong/.npm/_logs/2025-03-03T03_08_56_249Z-eresolve-report.txt
npm error A complete log of this run can be found in: /Users/jong/.npm/_logs/2025-03-03T03_08_56_249Z-debug-0.log
```

の解消。

以下issueがリリースされたら、TypeScript 5.8.2に戻す

https://github.com/typescript-eslint/typescript-eslint/issues/10884